### PR TITLE
Add prestissimo by default

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Richard Tuin <richard@egeniq.com>
 
 RUN usermod -a -G root www-data
 
-RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales
+RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales && rm -rf /var/lib/apt/lists/*
 
 # Locales
 COPY assets/locale.gen /etc/locale.gen
@@ -31,6 +31,8 @@ COPY ./assets/install_composer.sh /install_composer.sh
 RUN /install_composer.sh && \
     mv composer.phar /usr/local/bin/composer && \
     rm /install_composer.sh
+
+RUN composer global require hirak/prestissimo
 
 ONBUILD COPY src /src
 

--- a/7.2-nginx/Dockerfile
+++ b/7.2-nginx/Dockerfile
@@ -48,6 +48,8 @@ RUN /install_composer.sh && \
     mv composer.phar /usr/local/bin/composer && \
     rm /install_composer.sh
 
+RUN composer global require hirak/prestissimo
+
 ONBUILD COPY src /src
 
 # Preferably run composer install during build-time

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Richard Tuin <richard@egeniq.com>
 
 RUN usermod -a -G root www-data
 
-RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales
+RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales && rm -rf /var/lib/apt/lists/*
 
 # Locales
 COPY assets/locale.gen /etc/locale.gen
@@ -31,6 +31,8 @@ COPY ./assets/install_composer.sh /install_composer.sh
 RUN /install_composer.sh && \
     mv composer.phar /usr/local/bin/composer && \
     rm /install_composer.sh
+
+RUN composer global require hirak/prestissimo
 
 ONBUILD COPY src /src
 


### PR DESCRIPTION
Prestissimo fetches and installs composer dependencies in parallel, this makes a composer install significantly faster.
Must have until it is [merged with composer core](https://github.com/composer/composer/pull/5293).