### PR TITLE
Add image for PHP 7.3

### DIFF
--- a/7.2-nginx/Dockerfile
+++ b/7.2-nginx/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Richard Tuin <richard@egeniq.com>
 RUN usermod -a -G root www-data
 
 RUN apt-get update \
-    && apt-get install -y curl wget git zlib1g-dev locales gnupg \
+    && apt-get install -y curl wget git zlib1g-dev locales gnupg unzip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./assets/nginx_signing.key /root/nginx_signing.key

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Richard Tuin <richard@egeniq.com>
 
 RUN usermod -a -G root www-data
 
-RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales unzip && rm -rf /var/lib/apt/lists/*
 
 # Locales
 COPY assets/locale.gen /etc/locale.gen

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:5.6-apache
+FROM php:7.3-apache
 
 MAINTAINER Richard Tuin <richard@egeniq.com>
 
 RUN usermod -a -G root www-data
 
-RUN apt-get update && apt-get install -y curl wget git zlib1g-dev locales unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl wget git zlib1g-dev libzip-dev locales unzip && rm -rf /var/lib/apt/lists/*
 
 # Locales
 COPY assets/locale.gen /etc/locale.gen

--- a/7.3/assets/entrypoint.sh
+++ b/7.3/assets/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Run composer install now if the source was unavailable during build-time (ie. dev environments).
+if [ -f "composer.json" ] && [ ! -d "vendor/composer" ]; then
+    echo "Installing composer dependencies..."
+    composer install --prefer-dist --no-progress --no-ansi -a -n
+fi
+
+exec "$@"

--- a/7.3/assets/install_composer.sh
+++ b/7.3/assets/install_composer.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# source: https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/7.3/assets/locale.gen
+++ b/7.3/assets/locale.gen
@@ -1,0 +1,3 @@
+nl_NL.UTF-8 UTF-8
+en_GB.UTF-8 UTF-8
+en_US.UTF-8 UTF-8

--- a/7.3/assets/php-custom.ini
+++ b/7.3/assets/php-custom.ini
@@ -1,0 +1,5 @@
+log_errors = 1
+
+opcache.max_accelerated_files = 60000
+
+date.timezone = "Europe/Amsterdam"

--- a/7.3/assets/vhost.conf
+++ b/7.3/assets/vhost.conf
@@ -1,0 +1,14 @@
+<Directory /src>
+	AllowOverride All
+	Require all granted
+</Directory>
+
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /src/public
+
+	DirectoryIndex index.php
+
+	ErrorLog /dev/stderr
+	CustomLog /dev/stdout combined
+</VirtualHost>

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 These Docker images are based on the official PHP images, 
 with several complementary packages and sensible default 
-configuration options for production-grade deployments. 
+configuration options for production-grade deployments.
 
 ## Supported tags
 
 * 5.6-onbuild (uses apache)
 * 7.2-onbuild (uses apache)
+* 7.3-onbuild (uses apache)
 * 7.2-nginx-onbuild
 
 ## Installed packages and extensions

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,1 +1,1 @@
-FROM egeniq/php:7.2-onbuild
+FROM egeniq/php:7.3-onbuild


### PR DESCRIPTION
The Dockerfile and assets are largely the same as the other apache-based images, except it uses the PHP 7.3 base image.